### PR TITLE
Fix spelling of "light blue" in GetTolColors

### DIFF
--- a/R/GetTolColors.R
+++ b/R/GetTolColors.R
@@ -308,7 +308,7 @@ GetTolColors <- function(n, scheme="smooth rainbow", alpha=NULL, start=0, end=1,
              "dark red"    = "#663333",
              "dark grey"   = "#555555")
   } else if (scheme == "light") {
-    pal <- c("libht blue"   = "#77AADD",
+    pal <- c("light blue"   = "#77AADD",
              "orange"       = "#EE8866",
              "light yellow" = "#EEDD88",
              "pink"         = "#FFAABB",


### PR DESCRIPTION
Great package, just happened to notice this while playing around with it!